### PR TITLE
Update make_certs.bat

### DIFF
--- a/scripts/make_certs.bat
+++ b/scripts/make_certs.bat
@@ -36,6 +36,10 @@ copy identity.p12 ..\server\Identity.p12
 
 echo  7. Generating keys and certs for plist generation
 openssl req -inform pem -outform der -in identity.csr -out customer.der
+
+# Rename identity.csr to be used with the iOS Provisioning Portal
+rename identity.csr customer.csr
+
 copy Identity.p12 ..\vendor-signing\com\softhinker\vendor.p12
 copy customer.der ..\vendor-signing\com\softhinker\customer.der
 


### PR DESCRIPTION
Minor fix to the script, in the Windows version renaming identity.csr to customer.csr is missing and it's a bit confusing to follow the instructions.
